### PR TITLE
Fix project intermediate outputs being clobbered

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,9 +4,6 @@
     <!-- Path to root of the repository -->
     <RepoRoot>$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '..'))))\</RepoRoot>
 
-    <!-- Store intermediate build outputs in a top-level obj directory -->
-    <BaseIntermediateOutputPath>$(RepoRoot)obj\</BaseIntermediateOutputPath>
-
     <!-- Store build outputs in a top-level bin directory -->
     <OutputPath>$(RepoRoot)bin\$(Configuration)\</OutputPath>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,6 @@ steps:
     platform: $(buildPlatform)
     configuration: Debug
     maximumCpuCount: true
-    restoreNugetPackages: true
 
 - task: VSTest@2
 


### PR DESCRIPTION
Unfortunately previous PR https://github.com/ralish/DecodeWheaRecord/pull/1 introduced build flakiness, as you can see there:
https://dev.azure.com/nexiom/DecodeWheaRecord/_build/results?buildId=75&view=results
This PR fixes it.

It turned out that during the "nuget restore" command execution Nuget was trying to create 2 different project.assets.json files in the same folder. And a build was successful only if the last such file was about the project with tests.
Now Nuget creates these files in different folders, so the building process is robust.

Also, the restoreNugetPackages option for VSBuild@1 Azure DevOps pipeline task is deprecated and replaced NuGetCommand@2 task, so I deleted it