### PR TITLE
Add build target for .NET 8

### DIFF
--- a/src/DecodeWheaRecord.Tests/DecodeWheaRecord.Tests.csproj
+++ b/src/DecodeWheaRecord.Tests/DecodeWheaRecord.Tests.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <!-- Build configuration -->
     <IsTestProject>true</IsTestProject>
-    <TargetFramework>net8.0</TargetFramework>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/src/DecodeWheaRecord/DecodeWheaRecord.csproj
+++ b/src/DecodeWheaRecord/DecodeWheaRecord.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <!-- Build configuration -->
-    <TargetFramework>net8.0</TargetFramework>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <StartupObject>DecodeWheaRecord.Program</StartupObject>
@@ -11,7 +10,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <!-- AssemblyInfo metadata -->
     <AssemblyTitle>Decode WHEA Record</AssemblyTitle>
-    <Version>0.4.1</Version>
+    <Version>0.4.2</Version>
     <NeutralLanguage>en-AU</NeutralLanguage>
     <Product>Decode WHEA Record</Product>
     <Description>Decodes Windows Hardware Event Architecture records</Description>

--- a/src/DecodeWheaRecord/Events/Hardware/PciExpress.cs
+++ b/src/DecodeWheaRecord/Events/Hardware/PciExpress.cs
@@ -311,9 +311,9 @@ namespace DecodeWheaRecord.Events.Hardware {
             if (_ErrorHandlerType != PCI_EXPRESS_DEVICE_TYPE.RootPort &&
                 _ErrorHandlerType != PCI_EXPRESS_DEVICE_TYPE.DownstreamSwitchPort &&
                 _ErrorHandlerType != PCI_EXPRESS_DEVICE_TYPE.RootComplexEventCollector) {
-                var devTypeRp = Enum.GetName(PCI_EXPRESS_DEVICE_TYPE.RootPort);
-                var devTypeDsp = Enum.GetName(PCI_EXPRESS_DEVICE_TYPE.DownstreamSwitchPort);
-                var devTypeRcec = Enum.GetName(PCI_EXPRESS_DEVICE_TYPE.RootComplexEventCollector);
+                var devTypeRp = Enum.GetName(typeof(PCI_EXPRESS_DEVICE_TYPE), PCI_EXPRESS_DEVICE_TYPE.RootPort);
+                var devTypeDsp = Enum.GetName(typeof(PCI_EXPRESS_DEVICE_TYPE), PCI_EXPRESS_DEVICE_TYPE.DownstreamSwitchPort);
+                var devTypeRcec = Enum.GetName(typeof(PCI_EXPRESS_DEVICE_TYPE), PCI_EXPRESS_DEVICE_TYPE.RootComplexEventCollector);
                 var checkCalc = $"{ErrorHandlerType} != ({devTypeRp} || {devTypeDsp} || {devTypeRcec})";
                 throw new InvalidDataException($"{nameof(ErrorHandlerType)} is not valid for the event: {checkCalc}");
             }

--- a/src/DecodeWheaRecord/Internal/HexStringJsonConverter.cs
+++ b/src/DecodeWheaRecord/Internal/HexStringJsonConverter.cs
@@ -44,7 +44,7 @@ namespace DecodeWheaRecord.Internal {
                     writer.WriteValue($"0x{value:X16}");
                     break;
                 case byte[] bytes:
-                    writer.WriteValue(Convert.ToHexString(bytes));
+                    writer.WriteValue(BitConverter.ToString(bytes).Replace("-", null));
                     break;
                 case BigInteger bigInt:
                     if (bigInt.Sign == -1) {

--- a/src/DecodeWheaRecord/Internal/WheaRecord.cs
+++ b/src/DecodeWheaRecord/Internal/WheaRecord.cs
@@ -66,7 +66,7 @@ namespace DecodeWheaRecord.Internal {
         }
 
         protected WheaRecord(Type structType, uint structOffset, uint bytesMinimum, uint bytesRemaining) {
-            ArgumentNullException.ThrowIfNull(structType);
+            if (structType == null) throw new ArgumentNullException(nameof(structType));
 
             if (bytesRemaining < bytesMinimum) {
                 var msg = $"Structure requires {bytesMinimum} bytes but only {bytesRemaining} bytes remaining.";
@@ -147,7 +147,7 @@ namespace DecodeWheaRecord.Internal {
         }
 
         private static uint GetSectionOffset(WHEA_ERROR_RECORD_SECTION_DESCRIPTOR sectionDsc) {
-            ArgumentNullException.ThrowIfNull(sectionDsc);
+            if (sectionDsc == null) throw new ArgumentNullException(nameof(sectionDsc));
             return sectionDsc.SectionOffset;
         }
     }


### PR DESCRIPTION
I've updated the utility to use .NET 8 from .NET 4.7.2. This has brought with it some very minor changes in the usages of APIs, but no logic fixes were required.