### PR TITLE
Add error handling for section decoding in `WHEA_ERROR_RECORD`

### DIFF
--- a/src/DecodeWheaRecord/Errors/ErrorRecord.cs
+++ b/src/DecodeWheaRecord/Errors/ErrorRecord.cs
@@ -60,7 +60,8 @@ namespace DecodeWheaRecord.Errors {
 
             var bytesRemaining = recordSize - sectionDsc.SectionOffset; // TODO: Factor in adjacent sections
 
-            switch (sectionDsc.SectionTypeGuid) {
+            try {
+                switch (sectionDsc.SectionTypeGuid) {
                 /*
                  * Standard sections
                  */
@@ -157,6 +158,11 @@ namespace DecodeWheaRecord.Errors {
                     WarnOutput($"Unsupported section: {sectionDsc.SectionTypeGuid}", StructType.Name);
                     section = new UnsupportedError(sectionDsc, recordAddr, bytesRemaining);
                     break;
+                }
+            } catch (Exception ex) {
+                // Warn and treat as unsupported if section parsing fails.
+                WarnOutput($"Exception while decoding section {sectionDsc.SectionTypeGuid}: {ex.Message}", StructType.Name);
+                section = new UnsupportedError(sectionDsc, recordAddr, bytesRemaining);
             }
 
             return section;


### PR DESCRIPTION
This change allows the decoder to continue if a unsupported or malformed section exists. It logs a warning instead of failing the whole record. 

Added warnings for unknown section GUIDs and exceptions.
Fallback to UnsupportedError for sections that can't be parsed.
Keeps the decoder running even if some sections are bad.

This is an example that would crash the decoder previously, but now returns decoded sections
```435045521002FFFFFFFF03000200000002000000A0030000230A0C000E0B19140000000000000000000000000000000000000000000000000000000000000000BDC407CF89B7184EB3C41F732CB57131B18BCE2DD7BD0E45B9AD9CF4EBD4F890C0B1AAE01855DC0100000000455200000000000000000000000000000000000058010000C00000000003000001000000ADCC7698B447DB4BB65E16F193C4F3DB0000000000000000000000000000000002000000000000000000000000000000000000000000000018020000800000000003000000000000B0A03EDC44A19747B95B53FA242B6E1D0000000000000000000000000000000002000000000000000000000000000000000000000000000098020000080100000003000000000000011D1E8AF94257459C33565E5CC3F7E8000000000000000000000000000000000200000000000000000000000000000000000000000000007F010000000000000002040000030000110FA0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000007000000000000001000000000000000110FA000000810100B32DA7EFFFB8B170000000000000000000000000000000000000000000000000000000000000000B3F8F31CB1C5A249AA595EEF92FFA63C01000000000000009E07C0200400000000000000000000000000000000000000000000000000000000000000000000000200000002000000A87A8BAE5F55DC0110000000000000000000000000000000000000001B0000000B080200000020D8000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000```